### PR TITLE
Fix PHP Warning "strpos(): Empty needle"

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -249,7 +249,7 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
         $namespaces = array();
         foreach($searchdata as $ns) {
             foreach($excludes as $exclude) {
-                if(strpos($ns['id'], $exclude) === 0) {
+                if( ! empty($exclude) && strpos($ns['id'], $exclude) === 0) {
                     continue 2;
                 }
             }


### PR DESCRIPTION
If `$exclude` is empty, it generates many PHP warnings:

```php
 PHP Warning:  strpos(): Empty needle in /var/www/wiki/lib/plugins/addnewpage/syntax.php on line 249
```

This change fix it.