### PR TITLE
Fix PHP 8 warnings when triggered via CLI

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -229,8 +229,8 @@ class syntax_plugin_addnewpage extends SyntaxPlugin
     {
         global $INFO;
 
-        $selfid = $INFO['id'];
-        $selfns = getNS($selfid);
+        $selfid = $INFO['id'] ?? '';
+        $selfns = $selfid ? getNS($selfid) : '';
         // replace the input variable with something unique that survives cleanID
         $keep = sha1(time());
 


### PR DESCRIPTION
Very simple fix for when $INFO is not available.